### PR TITLE
chore: Node.js 24 compatibility — update actions and add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Build and Release
@@ -59,7 +62,7 @@ jobs:
     steps:
       # Get the machine ready to build
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Add Rust Target
         run: rustup target add ${{ matrix.target.rustTarget }}
@@ -85,7 +88,7 @@ jobs:
         run: cargo build --release --target ${{ matrix.target.rustTarget }}
 
       - name: Upload Asset
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.APP_NAME }}-${{ matrix.target.rustTarget }}${{ endsWith(matrix.target.rustTarget, '-windows-gnu') && '.exe' || '' }}
           path: ./target/${{ matrix.target.rustTarget }}/release/${{ env.APP_NAME }}${{ endsWith(matrix.target.rustTarget, '-windows-gnu') && '.exe' || '' }}


### PR DESCRIPTION
## Summary

Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` as a workflow-level environment variable to all GitHub Actions workflow files.

## Why

GitHub is migrating Actions runners from Node.js 20 to Node.js 24. This environment variable opts into the new runtime ahead of the forced migration, allowing us to:

- **Detect compatibility issues early** before the automatic cutover
- **Control the rollout** by opting in on our own schedule
- **Ensure CI/CD reliability** by validating all actions work with Node.js 24

## Changes

- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to workflow-level `env:` blocks
- Files that already had the variable were left unchanged

## References

- [GitHub Actions: All actions will run on Node20 instead of Node16 by default](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)
- [GitHub Actions: Actions Runner support for Node.js 24](https://github.blog/changelog/2025-05-06-github-actions-actions-runner-support-for-node-js-24/)
